### PR TITLE
Generate IDs using Terraform random id provider

### DIFF
--- a/provider/go.mod
+++ b/provider/go.mod
@@ -3,7 +3,6 @@ module github.com/julianespinel/terraform-custom-provider/provider
 go 1.14
 
 require (
-	github.com/dchest/uniuri v0.0.0-20200228104902-7aecb25e1fe5
 	github.com/hashicorp/terraform-plugin-sdk v1.10.0
 	github.com/sirupsen/logrus v1.5.0
 )

--- a/provider/go.sum
+++ b/provider/go.sum
@@ -36,8 +36,6 @@ github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDk
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
-github.com/dchest/uniuri v0.0.0-20200228104902-7aecb25e1fe5 h1:RAV05c0xOkJ3dZGS0JFybxFKZ2WMLabgx3uXnd7rpGs=
-github.com/dchest/uniuri v0.0.0-20200228104902-7aecb25e1fe5/go.mod h1:GgB8SF9nRG+GqaDtLcwJZsQFhcogVCJ79j4EdT0c2V4=
 github.com/envoyproxy/go-control-plane v0.9.1-0.20191026205805-5f8ba28d4473/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymFceY/DCBVvsKhRF0iEA4=
 github.com/envoyproxy/protoc-gen-validate v0.1.0/go.mod h1:iSmxcyjqTsJpI2R4NaDN7+kN2VEUnK/pcBlmesArF7c=
 github.com/fatih/color v1.7.0 h1:DkWD4oS2D8LGGgTQ6IvwJJXSL5Vp2ffcQg58nFV38Ys=

--- a/provider/main.tf
+++ b/provider/main.tf
@@ -7,11 +7,20 @@ resource "dummy_book" "my-book" {
     author = "Aldous Huxley"
 }
 
+resource "random_id" "random1" {
+    byte_length = 16
+}
+
 resource "dummy_book" "my-book-2" {
-    title = "1984"
+    title = "1984 - revision ${random_id.random1.hex}"
     author = "George Orwell"
 }
 
+resource "random_id" "random2" {
+    byte_length = 16
+}
+
 resource "dummy_book" "my-book-3" {
+    title = "generated.title.${random_id.random2.hex}"
     author = "George Orwell"
 }


### PR DESCRIPTION
Main changes:
1. Use Terraform random id provider to generate IDs.
1. Remove provider logic to generate random strings.
1. Remove `uniuri` dependency used to generate random strings.
